### PR TITLE
feat: deep typing for template

### DIFF
--- a/projects/ng-polymorpheus/src/directives/outlet.ts
+++ b/projects/ng-polymorpheus/src/directives/outlet.ts
@@ -76,7 +76,7 @@ export class PolymorpheusOutletDirective<C> implements OnChanges, DoCheck {
     static ngTemplateContextGuard<T>(
         _dir: PolymorpheusOutletDirective<T>,
         _ctx: any,
-    ): _ctx is PolymorpheusContext<string> {
+    ): _ctx is PolymorpheusContext<T extends PolymorpheusPrimitive ? T : never> {
         return true;
     }
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

All types are reduced to string

```ts
type IconType = 'success' | 'error';

type Icon = `${IconType}:${string}`;

class Component {
   @Input()
   icon: Icon;

   getIconType(icon: Icon): IconType {
      return icon.split(':')[0];
   }
}
```

```html
<ng-container *polymorpheusOutlet="icon as icon">
   {{ getIconType(icon) }} // Error: string is not assignable to type Icon
</ng-container>
```

## What is the new behavior?

Primitive types are preserved, the rest are deleted

```ts
type IconType = 'success' | 'error';

type Icon = `${IconType}:${string}`;

class Component {
   @Input()
   icon: Icon;

   getIconType(icon: Icon): IconType {
      return icon.split(':')[0];
   }
}
```

```html
<ng-container *polymorpheusOutlet="icon as icon">
   {{ getIconType(icon) }} // All ok
</ng-container>
```
