### PR TITLE
fix: support primitive context in templates and components

### DIFF
--- a/projects/ng-polymorpheus/src/directives/outlet.ts
+++ b/projects/ng-polymorpheus/src/directives/outlet.ts
@@ -13,6 +13,7 @@ import {PolymorpheusComponent} from '../classes/component';
 import {PolymorpheusContext} from '../classes/context';
 import type {PolymorpheusContent} from '../types/content';
 import type {PolymorpheusPrimitive} from '../types/primitive';
+import {isPrimitive} from '../utils/is-primitive';
 import {PolymorpheusTemplate} from './template';
 
 @Directive({
@@ -53,9 +54,11 @@ export class PolymorpheusOutlet<C> implements OnChanges, DoCheck {
 
         const proxy =
             context &&
-            (new Proxy(context as object, {
+            (new Proxy(ensureContext(context) as object, {
                 get: (_, key) =>
-                    this.getContext()?.[key as keyof (C | PolymorpheusContext<any>)],
+                    ensureContext(this.getContext())?.[
+                        key as keyof (C | PolymorpheusContext<any>)
+                    ],
             }) as unknown as C);
 
         if (isComponent(this.content)) {
@@ -116,4 +119,14 @@ function isTemplate<C>(
     content: PolymorpheusContent<C>,
 ): content is PolymorpheusTemplate<C> | TemplateRef<C> {
     return isDirective(content) || content instanceof TemplateRef;
+}
+
+function ensureContext<C>(
+    context: C | PolymorpheusContext<any> | undefined,
+): C | PolymorpheusContext<any> | undefined {
+    if (context && isPrimitive(context)) {
+        return new PolymorpheusContext(context);
+    }
+
+    return context;
 }

--- a/projects/ng-polymorpheus/src/tests/outlet.spec.ts
+++ b/projects/ng-polymorpheus/src/tests/outlet.spec.ts
@@ -285,5 +285,13 @@ describe('PolymorpheusOutlet', () => {
             expect(text()).toBe('Component: number');
             expect(COUNTER).toBe(counter);
         });
+
+        it('create a non-object context', () => {
+            testComponent.context = 'Hello World';
+            testComponent.content = new PolymorpheusComponent(ComponentContent);
+            fixture.detectChanges();
+
+            expect(text()).toBe('Component: Hello World');
+        });
     });
 });

--- a/projects/ng-polymorpheus/src/tests/primitive.spec.ts
+++ b/projects/ng-polymorpheus/src/tests/primitive.spec.ts
@@ -1,0 +1,27 @@
+/* eslint-disable sonarjs/no-primitive-wrappers,no-new-wrappers,unicorn/new-for-builtins */
+import {describe, expect, it} from '@jest/globals';
+
+import {isPrimitive} from '../utils/is-primitive';
+
+describe('isPrimitive', () => {
+    it('should return true for primitive', () => {
+        expect(isPrimitive(undefined)).toBe(true);
+        expect(isPrimitive(null)).toBe(true);
+        expect(isPrimitive(12)).toBe(true);
+        expect(isPrimitive(Number(12))).toBe(true);
+        expect(isPrimitive(Number(12))).toBe(true);
+        expect(isPrimitive('Hello world')).toBe(true);
+        // noinspection JSPrimitiveTypeWrapperUsage
+        expect(isPrimitive(new String('Hello world'))).toBe(true);
+        expect(isPrimitive(true)).toBe(true);
+        // noinspection JSPrimitiveTypeWrapperUsage
+        expect(isPrimitive(new Boolean(true))).toBe(true);
+    });
+
+    it('should return false for non primitive', () => {
+        expect(isPrimitive([])).toBe(false);
+        expect(isPrimitive({})).toBe(false);
+        expect(isPrimitive(() => {})).toBe(false);
+        expect(isPrimitive(new (class {})())).toBe(false);
+    });
+});

--- a/projects/ng-polymorpheus/src/tests/primitive.spec.ts
+++ b/projects/ng-polymorpheus/src/tests/primitive.spec.ts
@@ -11,11 +11,7 @@ describe('isPrimitive', () => {
         expect(isPrimitive(Number(12))).toBe(true);
         expect(isPrimitive(Number(12))).toBe(true);
         expect(isPrimitive('Hello world')).toBe(true);
-        // noinspection JSPrimitiveTypeWrapperUsage
-        expect(isPrimitive(new String('Hello world'))).toBe(true);
         expect(isPrimitive(true)).toBe(true);
-        // noinspection JSPrimitiveTypeWrapperUsage
-        expect(isPrimitive(new Boolean(true))).toBe(true);
     });
 
     it('should return false for non primitive', () => {
@@ -23,5 +19,11 @@ describe('isPrimitive', () => {
         expect(isPrimitive({})).toBe(false);
         expect(isPrimitive(() => {})).toBe(false);
         expect(isPrimitive(new (class {})())).toBe(false);
+
+        // noinspection JSPrimitiveTypeWrapperUsage
+        expect(isPrimitive(new String('Hello world'))).toBe(false);
+
+        // noinspection JSPrimitiveTypeWrapperUsage
+        expect(isPrimitive(new Boolean(true))).toBe(false);
     });
 });

--- a/projects/ng-polymorpheus/src/utils/is-primitive.ts
+++ b/projects/ng-polymorpheus/src/utils/is-primitive.ts
@@ -1,11 +1,3 @@
 export function isPrimitive(value: unknown): boolean {
-    return (
-        value === null ||
-        !(typeof value === 'object' || typeof value === 'function') ||
-        value instanceof Number ||
-        value instanceof String ||
-        value instanceof Boolean ||
-        value instanceof Symbol ||
-        value instanceof BigInt
-    );
+    return Object(value) !== value;
 }

--- a/projects/ng-polymorpheus/src/utils/is-primitive.ts
+++ b/projects/ng-polymorpheus/src/utils/is-primitive.ts
@@ -1,0 +1,11 @@
+export function isPrimitive(value: unknown): boolean {
+    return (
+        value === null ||
+        !(typeof value === 'object' || typeof value === 'function') ||
+        value instanceof Number ||
+        value instanceof String ||
+        value instanceof Boolean ||
+        value instanceof Symbol ||
+        value instanceof BigInt
+    );
+}

--- a/projects/ng-polymorpheus/tsconfig.lib.json
+++ b/projects/ng-polymorpheus/tsconfig.lib.json
@@ -6,7 +6,7 @@
         "declaration": true,
         "inlineSources": true,
         "types": [],
-        "lib": ["dom", "es2018"]
+        "lib": ["dom", "es2020"]
     },
     "angularCompilerOptions": {
         "annotateForClosureCompiler": true,


### PR DESCRIPTION
Fixes #449 

## Before

<img width="662" alt="image" src="https://github.com/user-attachments/assets/92860494-622a-49a7-9086-bc67f291784c" />
