### PR TITLE
Fix: allow injecting falsy values

### DIFF
--- a/projects/ng-polymorpheus/src/classes/component.ts
+++ b/projects/ng-polymorpheus/src/classes/component.ts
@@ -17,7 +17,7 @@ export class PolymorpheusComponent<T> {
     public createInjector<C>(injector: Injector, useValue?: C): Injector {
         return Injector.create({
             parent: this.i || injector,
-            providers: useValue ? [provideContext(useValue)] : [],
+            providers: [provideContext(useValue)],
         });
     }
 }

--- a/projects/ng-polymorpheus/src/classes/component.ts
+++ b/projects/ng-polymorpheus/src/classes/component.ts
@@ -17,7 +17,7 @@ export class PolymorpheusComponent<T> {
     public createInjector<C>(injector: Injector, useValue?: C): Injector {
         return Injector.create({
             parent: this.i || injector,
-            providers: [provideContext(useValue)],
+            providers: useValue !== undefined ? [provideContext(useValue)] :  []
         });
     }
 }

--- a/projects/ng-polymorpheus/src/directives/outlet.ts
+++ b/projects/ng-polymorpheus/src/directives/outlet.ts
@@ -45,7 +45,7 @@ export class PolymorpheusOutlet<C> implements OnChanges, DoCheck {
     public ngOnChanges({content}: SimpleChanges): void {
         const context = this.getContext();
 
-        this.update();
+        this.updateComponentInputs();
         this.c?.injector.get(ChangeDetectorRef).markForCheck();
 
         if (!content) {
@@ -54,33 +54,25 @@ export class PolymorpheusOutlet<C> implements OnChanges, DoCheck {
 
         this.vcr.clear();
 
-        const proxy =
-            context &&
-            (new Proxy(ensureContext(context) as object, {
-                get: (_, key) =>
-                    ensureContext(this.getContext())?.[
-                        key as keyof (C | PolymorpheusContext<any>)
-                    ],
-            }) as unknown as C);
-
+        const liveContext = this.createLiveContextProxy();
         if (isComponent(this.content)) {
-            this.process(this.content, proxy);
-            this.update();
+            this.createComponent(this.content, liveContext);
+            this.updateComponentInputs();
         } else if (
             (context instanceof PolymorpheusContext && context.$implicit) != null
         ) {
-            this.vcr.createEmbeddedView(this.template, proxy, {injector: this.i});
+            this.vcr.createEmbeddedView(this.template, liveContext, {injector: this.i});
         }
     }
 
     public ngDoCheck(): void {
-        if (isDirective(this.content)) {
+        if (isPolymorpheusTemplate(this.content)) {
             this.content.check();
         }
     }
 
     private get template(): TemplateRef<unknown> {
-        if (isDirective(this.content)) {
+        if (isPolymorpheusTemplate(this.content)) {
             return this.content.template;
         }
 
@@ -97,13 +89,13 @@ export class PolymorpheusOutlet<C> implements OnChanges, DoCheck {
               );
     }
 
-    private process(content: PolymorpheusComponent<unknown>, proxy?: C): void {
+    private createComponent(content: PolymorpheusComponent<unknown>, proxy?: C): void {
         const injector = content.createInjector(this.i, proxy);
 
         this.c = this.vcr.createComponent(content.component, {injector});
     }
 
-    private update(): void {
+    private updateComponentInputs(): void {
         const {context, content} = this;
 
         if (!context || typeof context !== 'object' || !isComponent(content)) {
@@ -118,9 +110,25 @@ export class PolymorpheusOutlet<C> implements OnChanges, DoCheck {
             }
         }
     }
+
+    /**
+     * Creates a stable context object for Angular templates/injection.
+     *
+     * The proxy always reads values from the latest context,
+     * so embedded views and injected context do not become stale
+     * when `this.context` changes.
+     */
+    private createLiveContextProxy(): C {
+        return   (new Proxy(ensureContext(this.context) as object, {
+            get: (_, key) =>
+                ensureContext(this.getContext())?.[
+                    key as keyof (C | PolymorpheusContext<any>)
+                    ],
+        })   as unknown as C)  ;
+    }
 }
 
-function isDirective<C>(
+function isPolymorpheusTemplate<C>(
     content: PolymorpheusContent<C>,
 ): content is PolymorpheusTemplate<C> {
     return content instanceof PolymorpheusTemplate;
@@ -135,11 +143,11 @@ function isComponent<C>(
 function isTemplate<C>(
     content: PolymorpheusContent<C>,
 ): content is PolymorpheusTemplate<C> | TemplateRef<C> {
-    return isDirective(content) || content instanceof TemplateRef;
+    return isPolymorpheusTemplate(content) || content instanceof TemplateRef;
 }
 
 function ensureContext<C>(
     context: C | PolymorpheusContext<any> | undefined,
 ): C | PolymorpheusContext<any> | undefined {
-    return context && isPrimitive(context) ? new PolymorpheusContext(context) : context;
+    return isPrimitive(context) ? new PolymorpheusContext(context) : context;
 }

--- a/projects/ng-polymorpheus/src/directives/outlet.ts
+++ b/projects/ng-polymorpheus/src/directives/outlet.ts
@@ -55,8 +55,12 @@ export class PolymorpheusOutlet<C> implements OnChanges, DoCheck {
         this.vcr.clear();
 
         const liveContext = this.createLiveContextProxy();
+
         if (isComponent(this.content)) {
-            this.createComponent(this.content, liveContext);
+            this.createComponent(
+                this.content,
+                this.context === undefined ? undefined : liveContext,
+            );
             this.updateComponentInputs();
         } else if (
             (context instanceof PolymorpheusContext && context.$implicit) != null
@@ -119,12 +123,23 @@ export class PolymorpheusOutlet<C> implements OnChanges, DoCheck {
      * when `this.context` changes.
      */
     private createLiveContextProxy(): C {
-        return (new Proxy({}, {
-            get: (_, key) =>
-                ensureContext(this.getContext())?.[
-                    key as keyof (C | PolymorpheusContext<any>)
-                    ],
-        })   as unknown as C)  ;
+        const getEnsuredContext = () => ensureContext(this.getContext());
+
+        return new Proxy(getEnsuredContext() as object, {
+            get: (_, key) => getEnsuredContext()?.[key as keyof (C | PolymorpheusContext<any>)],
+            has: (_, key) => key in (getEnsuredContext() ?? {}),
+            ownKeys: () => Reflect.ownKeys(getEnsuredContext() as object),
+            getOwnPropertyDescriptor: (_, key) => {
+                const context = getEnsuredContext() as object;
+
+                return key in context
+                    ? {
+                          enumerable: true,
+                          configurable: true,
+                      }
+                    : undefined;
+            },
+        }) as unknown as C;
     }
 }
 

--- a/projects/ng-polymorpheus/src/directives/outlet.ts
+++ b/projects/ng-polymorpheus/src/directives/outlet.ts
@@ -119,7 +119,7 @@ export class PolymorpheusOutlet<C> implements OnChanges, DoCheck {
      * when `this.context` changes.
      */
     private createLiveContextProxy(): C {
-        return   (new Proxy(ensureContext(this.context) as object, {
+        return (new Proxy({}, {
             get: (_, key) =>
                 ensureContext(this.getContext())?.[
                     key as keyof (C | PolymorpheusContext<any>)

--- a/projects/ng-polymorpheus/src/tests/outlet.spec.ts
+++ b/projects/ng-polymorpheus/src/tests/outlet.spec.ts
@@ -13,6 +13,7 @@ import {
     type PolymorpheusContent,
     PolymorpheusOutlet,
     PolymorpheusTemplate,
+    provideContext,
 } from '@taiga-ui/polymorpheus';
 import {PolymorpheusContext} from "../classes/context";
 
@@ -110,8 +111,8 @@ describe('PolymorpheusOutlet', () => {
         template: 'Component:{{ context.$implicit }}',
         changeDetection: ChangeDetectionStrategy.Default,
     })
-    class PrimitiveContextComponent {
-        public readonly context =  injectContext<PolymorpheusContext<boolean>>();
+    class JustInjectContextComponent {
+        public readonly context = injectContext<PolymorpheusContext<boolean>>();
     }
 
     let fixture: ComponentFixture<TestComponent>;
@@ -323,13 +324,127 @@ describe('PolymorpheusOutlet', () => {
             [0, '0'],
             ['', ''],
             [null, ''],
-            [undefined, ''],
         ])('provides %p through injectContext', (context, expected) => {
             testComponent.context = context;
-            testComponent.content = new PolymorpheusComponent(PrimitiveContextComponent);
+            testComponent.content = new PolymorpheusComponent(JustInjectContextComponent);
             fixture.detectChanges();
 
-            expect(text()).toBe(`Component:${(expected)}`);
+            expect(text()).toBe(`Component:${expected}`);
         });
+    });
+
+    it('throws NullInjectorError when context input is not provided and parent has no context', () => {
+        testComponent.context = undefined;
+        testComponent.content = new PolymorpheusComponent(JustInjectContextComponent);
+
+        expect(() => fixture.detectChanges()).toThrow();
+    });
+
+    it('does not shadow parent context when context input is not provided', () => {
+        @Component({
+            imports: [PolymorpheusOutlet],
+            template: `
+                <ng-container *polymorpheusOutlet="content" />
+            `,
+            changeDetection: ChangeDetectionStrategy.Default,
+            providers: [provideContext({$implicit: 'parent'})],
+        })
+        class WithoutContextInput {
+            public content = new PolymorpheusComponent(ComponentContent);
+        }
+
+        const fallbackFixture = TestBed.createComponent(WithoutContextInput);
+
+        fallbackFixture.detectChanges();
+
+        expect(fallbackFixture.nativeElement.textContent.trim()).toBe(
+            'Component: parent',
+        );
+    });
+
+    it('updates proxy shape when context keys change', () => {
+        @Component({
+            template: '{{ keys }}',
+            changeDetection: ChangeDetectionStrategy.Default,
+        })
+        class ContextShapeComponent {
+            public readonly context = injectContext<any>();
+
+            public get keys(): string {
+                return Object.keys(this.context).sort().join(',');
+            }
+        }
+
+        testComponent.context = {
+            $implicit: {name: 'Ivan', age: 5},
+            loading: true,
+        };
+
+        testComponent.content = new PolymorpheusComponent(ContextShapeComponent);
+
+        fixture.detectChanges();
+
+        expect(text()).toBe('$implicit,loading');
+
+        testComponent.context = {
+            $implicit: {label: 'Igor', id: 3},
+            error: false,
+        };
+
+        fixture.detectChanges();
+
+        expect(text()).toBe('$implicit,error');
+    });
+
+    it('updates proxy shape when context changes from null to object', () => {
+        @Component({
+            template: '{{ keys }}',
+            changeDetection: ChangeDetectionStrategy.Default,
+        })
+        class ContextShapeComponent {
+            public readonly context = injectContext<any>();
+
+            public get keys(): string {
+                return Object.keys(this.context).sort().join(',');
+            }
+        }
+
+        testComponent.context = null;
+        testComponent.content = new PolymorpheusComponent(ContextShapeComponent);
+
+        fixture.detectChanges();
+
+        expect(text()).toBe('$implicit');
+
+        testComponent.context = {
+            $implicit: 'value',
+            loading: true,
+        };
+
+        fixture.detectChanges();
+
+        expect(text()).toBe('$implicit,loading');
+    });
+    it('keeps primitive context object behavior', () => {
+        @Component({
+            template: '{{ isContext }}:{{ hasImplicit }}:{{ keys }}:{{ spread }}:{{ json }}',
+            changeDetection: ChangeDetectionStrategy.Default,
+        })
+        class ContextShapeComponent {
+            public readonly context = injectContext<PolymorpheusContext<string>>();
+
+            public readonly isContext = this.context instanceof PolymorpheusContext;
+            public readonly hasImplicit = '$implicit' in this.context;
+            public readonly keys = Object.keys(this.context).join(',');
+            public readonly spread = Object.keys({...this.context}).join(',');
+            public readonly json = JSON.stringify(this.context);
+        }
+
+        testComponent.context = 'value';
+        testComponent.content = new PolymorpheusComponent(ContextShapeComponent);
+
+        fixture.detectChanges();
+
+        expect(text()).toBe('true:true:$implicit:$implicit:{"$implicit":"value"}');
     });
 });

--- a/projects/ng-polymorpheus/src/tests/outlet.spec.ts
+++ b/projects/ng-polymorpheus/src/tests/outlet.spec.ts
@@ -317,15 +317,14 @@ describe('PolymorpheusOutlet', () => {
         });
     });
 
-    describe('Falsy context values', () => {
-
+    describe('Falsy primitive context values for component content', () => {
         it.each([
             [false, 'false'],
             [0, '0'],
             ['', ''],
             [null, ''],
             [undefined, ''],
-        ])('provides falsy primitive context to component: %p', (context, expected) => {
+        ])('provides %p through injectContext', (context, expected) => {
             testComponent.context = context;
             testComponent.content = new PolymorpheusComponent(PrimitiveContextComponent);
             fixture.detectChanges();

--- a/projects/ng-polymorpheus/src/tests/outlet.spec.ts
+++ b/projects/ng-polymorpheus/src/tests/outlet.spec.ts
@@ -14,6 +14,7 @@ import {
     PolymorpheusOutlet,
     PolymorpheusTemplate,
 } from '@taiga-ui/polymorpheus';
+import {PolymorpheusContext} from "../classes/context";
 
 let COUNTER = 0;
 
@@ -103,6 +104,14 @@ describe('PolymorpheusOutlet', () => {
     })
     class WithInputs {
         public value = '';
+    }
+
+    @Component({
+        template: 'Component:{{ context.$implicit }}',
+        changeDetection: ChangeDetectionStrategy.Default,
+    })
+    class PrimitiveContextComponent {
+        public readonly context =  injectContext<PolymorpheusContext<boolean>>();
     }
 
     let fixture: ComponentFixture<TestComponent>;
@@ -305,6 +314,23 @@ describe('PolymorpheusOutlet', () => {
             fixture.detectChanges();
 
             expect(text()).toBe('New value');
+        });
+    });
+
+    describe('Falsy context values', () => {
+
+        it.each([
+            [false, 'false'],
+            [0, '0'],
+            ['', ''],
+            [null, ''],
+            [undefined, ''],
+        ])('provides falsy primitive context to component: %p', (context, expected) => {
+            testComponent.context = context;
+            testComponent.content = new PolymorpheusComponent(PrimitiveContextComponent);
+            fixture.detectChanges();
+
+            expect(text()).toBe(`Component:${(expected)}`);
         });
     });
 });


### PR DESCRIPTION
## Fix falsy context provider handling in `PolymorpheusComponent`

Previously falsy context values were skipped when creating the injector:
```html
<ng-container
    *polymorpheusOutlet="comp; context: trueContext"
/>

<ng-container
    *polymorpheusOutlet="comp; context: falseContext"
/>
```

```ts
// Parent component 
comp = new PolymorpheusComponent(Button);

trueContext = true; //  on injection POLYMORPHEUS_CONTEXT = { $implicit: true} will be passed
falseContext = false; // on injection POLYMORPHEUS_CONTEXT occurs Runtime error NULL_INJECTION.

// Child "Button" component
context = inject(POLYMORPHEUS_CONTEXT);

```

`trueContext` worked fine because the provider was created, but `falseContext` would result in `NullInjectorError` at runtime because no provider was registered for falsy values.
The same issue could happen with other falsy values like 0, '', null, or undefined.

This change avoids that by always providing the context provider.

## Additional small changes

- Added test coverage for falsy values
- Renamed some functions for better readability
  - `update` => `updateComponentInputs`
  - `process` => `createComponent`
- Removed unnecessary ensureContext call

